### PR TITLE
refactor test4-repair

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,11 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.7.5.201505241946</version>
+                <configuration>
+                    <excludes>
+                        <exclude>fr.inria.spirals.test4repair.*</exclude>
+                    </excludes>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/src/main/java/fr/inria/spirals/test4repair/Main.java
+++ b/src/main/java/fr/inria/spirals/test4repair/Main.java
@@ -1,9 +1,8 @@
-package fr.inria.spirals;
+package fr.inria.spirals.test4repair;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import fr.inria.spirals.json.JSONProject;
-import fr.inria.spirals.run.TaskBuilder;
 import fr.inria.spirals.util.Counter;
 
 import java.io.File;
@@ -30,7 +29,7 @@ public class Main {
     public static final String[] projectsName = new String[]{"chart", "lang", "math", "time"};
 
     public static void main(String[] args) throws MalformedURLException, ClassNotFoundException {
-        final File directoryOfResults = new File(PATH_TO_TEST4REPAIR_RESULTS);
+        final File directoryOfResults = new File(UtilTest4Repair.PATH_TO_TEST4REPAIR_RESULTS);
         if (directoryOfResults.listFiles() == null) {
             //TODO should clone repos test4repair-experiments
         } else {

--- a/src/main/java/fr/inria/spirals/test4repair/Run.java
+++ b/src/main/java/fr/inria/spirals/test4repair/Run.java
@@ -1,4 +1,4 @@
-package fr.inria.spirals.run;
+package fr.inria.spirals.test4repair;
 
 import fr.inria.spirals.asserts.log.Logger;
 import fr.inria.spirals.json.JSONTest;
@@ -30,7 +30,7 @@ public class Run {
         System.out.println(project + "#" + bugId + "::" + seed);
         List<JSONTest> testsResults = new ArrayList<>();
         Launcher spoon = buildSpoonModel(project, bugId, seed);
-        String cp = getBaseClassPath(project, bugId);
+        String cp = UtilTest4Repair.getBaseClassPath(project, bugId);
         cp += PATH_SEPARATOR + spoon.getEnvironment().getBinaryOutputDirectory();
         for (String indexTest : testsCaseName) {
             String testCaseName = indexToRealTestCaseName(spoon, indexTest, fullQualifiedName);
@@ -58,7 +58,7 @@ public class Run {
     }
 
     public static RepairCode run(Launcher spoon, String project, String bugId, String seed, String testCaseName, String fullQualifiedName) throws Throwable {
-        String cp = getBaseClassPath(project, bugId);
+        String cp = UtilTest4Repair.getBaseClassPath(project, bugId);
         cp += PATH_SEPARATOR + spoon.getEnvironment().getBinaryOutputDirectory();
         List<Failure> failures = TestRunner.runTest(
                 fullQualifiedName,
@@ -101,13 +101,13 @@ public class Run {
 
     private static Launcher buildSpoonModel(String project, String bugId, String seed) {
         Launcher spoon = new Launcher();
-        spoon.addInputResource(PATH_TO_TEST4REPAIR_RESULTS + project + FILE_SEPARATOR + bugId + FILE_SEPARATOR + seed);
+        spoon.addInputResource(UtilTest4Repair.PATH_TO_TEST4REPAIR_RESULTS + project + FILE_SEPARATOR + bugId + FILE_SEPARATOR + seed);
         spoon.addInputResource("src/main/java/fr/inria/spirals/asserts/log/Logger.java"); // adding the logger to the spoon model to compile and run it to fix assertions
         spoon.getEnvironment().setComplianceLevel(7);
         spoon.getEnvironment().setAutoImports(true);
         spoon.getEnvironment().setCommentEnabled(true);
         spoon.getEnvironment().setShouldCompile(true);
-        String cp = getBaseClassPath(project, bugId);
+        String cp = UtilTest4Repair.getBaseClassPath(project, bugId);
         spoon.getEnvironment().setSourceClasspath((cp).split(PATH_SEPARATOR));
         spoon.run();
         spoon.setSourceOutputDirectory("output" + FILE_SEPARATOR + project + FILE_SEPARATOR + bugId + FILE_SEPARATOR + seed);

--- a/src/main/java/fr/inria/spirals/test4repair/TaskBuilder.java
+++ b/src/main/java/fr/inria/spirals/test4repair/TaskBuilder.java
@@ -1,4 +1,4 @@
-package fr.inria.spirals.run;
+package fr.inria.spirals.test4repair;
 
 import fr.inria.spirals.json.JSONBugID;
 import fr.inria.spirals.json.JSONProject;
@@ -10,7 +10,8 @@ import org.json.simple.parser.JSONParser;
 import java.io.File;
 import java.io.FileReader;
 
-import static fr.inria.spirals.Main.projects;
+import static fr.inria.spirals.test4repair.UtilTest4Repair.*;
+import static fr.inria.spirals.test4repair.Main.projects;
 import static fr.inria.spirals.util.Util.*;
 
 /**
@@ -47,7 +48,7 @@ public class TaskBuilder {
                         projects.get(project).getJSONBugID(bugID).seeds.add(
                                 new JSONSeed(seedID,
                                         Run.runAllTestCaseName(project, bugID, seedID,
-                                                STRING_ARRAY_TO_INDEX.apply(valueBugExposingTest),
+                                                UtilTest4Repair.STRING_ARRAY_TO_INDEX.apply(valueBugExposingTest),
                                                 fullQualifiedName)));
                     } catch (Throwable e) {
                         throw new RuntimeException(e);
@@ -60,9 +61,9 @@ public class TaskBuilder {
     }
 
     private static String findFullQualifiedName(String project, String bugID, String seed) {
-        File current = new File(PATH_TO_TEST4REPAIR_RESULTS + project + "/" + bugID + "/" + seed);
+        File current = new File(UtilTest4Repair.PATH_TO_TEST4REPAIR_RESULTS + project + "/" + bugID + "/" + seed);
         if (current.listFiles() == null) {
-            throw new RuntimeException(PATH_TO_TEST4REPAIR_RESULTS + project + "/" + bugID + "/" + seed + " not found or empty");
+            throw new RuntimeException(UtilTest4Repair.PATH_TO_TEST4REPAIR_RESULTS + project + "/" + bugID + "/" + seed + " not found or empty");
         } else {
             current = current.listFiles()[0];
             StringBuilder fullQualifiedName = new StringBuilder();
@@ -71,7 +72,7 @@ public class TaskBuilder {
                 current = current.listFiles()[0];
             }
             fullQualifiedName.append(current.getName()).append(".");
-            fullQualifiedName.append(GET_ESTEST.apply(current.listFiles()));
+            fullQualifiedName.append(UtilTest4Repair.GET_ESTEST.apply(current.listFiles()));
             return fullQualifiedName.toString();
         }
     }

--- a/src/main/java/fr/inria/spirals/test4repair/UtilTest4Repair.java
+++ b/src/main/java/fr/inria/spirals/test4repair/UtilTest4Repair.java
@@ -1,0 +1,116 @@
+package fr.inria.spirals.test4repair;
+
+import fr.inria.spirals.util.Util;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.function.Function;
+
+/**
+ * Created by Benjamin DANGLOT
+ * benjamin.danglot@inria.fr
+ * on 30/05/17
+ */
+public class UtilTest4Repair {
+    public static final String PATH_TO_TEST4REPAIR = "../test4repair-experiments/";
+
+    public static final String PATH_TO_PROJECTS_JSON = PATH_TO_TEST4REPAIR +
+            "src" + Util.FILE_SEPARATOR +
+            "Nopol+UnsatGuided" + Util.FILE_SEPARATOR +
+            "src" + Util.FILE_SEPARATOR +
+            "main" + Util.FILE_SEPARATOR +
+            "java" + Util.FILE_SEPARATOR +
+            "data" + Util.FILE_SEPARATOR +
+            "projects" + Util.FILE_SEPARATOR; // TODO this is not java file, why put them into src/main/java ???
+
+    public static final String PATH_TO_TEST4REPAIR_RESULTS = PATH_TO_TEST4REPAIR + "results/Nopol-Test-Runing-Result/"; // + project + "/" + bugId + "/" + seed
+
+    public static final String RELATIVE_PATH_SRC_BIN_KEY = "binjava";
+
+    public static final String RELATIVE_PATH_TEST_BIN_KEY = "bintest";
+
+    public static final String PATH_TO_PROJECTS_REPOS = ".." + Util.FILE_SEPARATOR + "projects" + Util.FILE_SEPARATOR + "";
+
+    public static final String ES_MODULE_NAME = "evosuite-master";
+
+    public static final String EMPTY_ARRAY_AS_STRING = "[]";
+
+    public static final String BUG_EXPOSING_TEST_KEY = "BugExposingTest";
+
+    public static final String TEST_NAME = "_ESTest" + Util.EXTENSION_JAVA;
+
+    public static final Function<File[], String> GET_ESTEST = files ->
+            Arrays.stream(files)
+                    .filter(file -> file.getName().endsWith(TEST_NAME))
+                    .findFirst()
+                    .orElseThrow(() -> new RuntimeException("TestNotFound"))
+                    .getName();
+
+    public static final Function<String, String[]> STRING_ARRAY_TO_INDEX = string ->
+            string.split("\\[")[1].split("]")[0].replaceAll(" ", "").split(",");
+
+    public static String getBaseClassPath(String project, String bugId) {
+        final String relativePathToClasses = getRelativePathToClasses(project, bugId);
+        return relativePathToClasses + Util.PATH_SEPARATOR + getEvosuiteDependenciesPath();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static String getRelativePathToClasses(String project, String bugId) {
+        try {
+            JSONParser parser = new JSONParser();
+            JSONObject jsonObject = (JSONObject) parser.parse(
+                    new FileReader(new File(PATH_TO_PROJECTS_JSON + project + Util.EXTENSION_JSON))
+            );
+            final JSONObject src = (JSONObject) jsonObject.get("src");
+            final JSONObject rightVersionSources = (JSONObject) src.get(
+                    src.keySet().size() == 1 ?
+                            src.keySet().stream().findAny().orElseThrow(() -> new RuntimeException(project + "#" + bugId)) :
+                            src.get(bugId) != null ? bugId :
+                                    (src.keySet()
+                                            .stream()
+                                            .sorted()
+                                            .filter(key -> Integer.parseInt(bugId) - Integer.parseInt((String) key) <= 0).
+                                                    reduce((k1, k2) -> k1)
+                                            .orElseThrow(() -> new RuntimeException(project + "#" + bugId))
+                                            .toString()
+                                    )
+            );
+            return PATH_TO_PROJECTS_REPOS + project + "_" + bugId +
+                    Util.FILE_SEPARATOR + rightVersionSources.get(RELATIVE_PATH_SRC_BIN_KEY).toString()
+                    + Util.PATH_SEPARATOR +
+                    PATH_TO_PROJECTS_REPOS + project + "_" + bugId +
+                    Util.FILE_SEPARATOR + rightVersionSources.get(RELATIVE_PATH_TEST_BIN_KEY).toString();
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String getEvosuiteDependenciesPath() {
+        if (!new File("target/.cp").exists()) {
+            String cmd = "mvn dependency:build-classpath -Dmdep.outputFile=target/.cp";
+            try {
+                final Process exec = Runtime.getRuntime().exec(cmd);
+                exec.waitFor();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+        try (BufferedReader reader = new BufferedReader(new FileReader(new File("target/.cp")))) {
+            return Arrays.stream(reader.lines()
+                    .findFirst()
+                    .orElseThrow(RuntimeException::new)
+                    .split(Util.PATH_SEPARATOR))
+                    .filter(s -> s.contains(ES_MODULE_NAME))
+                    .findFirst()
+                    .orElseThrow(RuntimeException::new);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+}

--- a/src/main/java/fr/inria/spirals/util/Counter.java
+++ b/src/main/java/fr/inria/spirals/util/Counter.java
@@ -104,6 +104,9 @@ public class Counter {
 
     public static void print() {
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        if (!new File("output").exists()) {
+            new File("output").mkdir();
+        }
         try (FileWriter writer = new FileWriter(new File("output" + FILE_SEPARATOR + "metrics" + EXTENSION_JSON), false)) {
             JSONMetrics jsonMetrics = new JSONMetrics(
                     _getInstance().initialNumberOfTest,

--- a/src/main/java/fr/inria/spirals/util/Util.java
+++ b/src/main/java/fr/inria/spirals/util/Util.java
@@ -1,5 +1,6 @@
 package fr.inria.spirals.util;
 
+import fr.inria.spirals.test4repair.UtilTest4Repair;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 
@@ -18,10 +19,6 @@ import java.util.function.Predicate;
  */
 public class Util {
 
-    public static final String PATH_TO_TEST4REPAIR = "../test4repair-experiments/";
-
-    public static final String PATH_TO_TEST4REPAIR_RESULTS = PATH_TO_TEST4REPAIR + "results/Nopol-Test-Runing-Result/"; // + project + "/" + bugId + "/" + seed
-
     public static final String EXTENSION_JSON = ".json";
 
     public static final String PATH_SEPARATOR = System.getProperty("path.separator");
@@ -30,30 +27,7 @@ public class Util {
 
     public static final String FILE_SEPARATOR = System.getProperty("file.separator");
 
-    public static final String RELATIVE_PATH_SRC_BIN_KEY = "binjava";
-
-    public static final String RELATIVE_PATH_TEST_BIN_KEY = "bintest";
-
-    public static final String PATH_TO_PROJECTS_REPOS = ".." + FILE_SEPARATOR + "projects" + FILE_SEPARATOR + "";
-
-    public static final String PATH_TO_PROJECTS_JSON = PATH_TO_TEST4REPAIR +
-            "src" + FILE_SEPARATOR +
-            "Nopol+UnsatGuided" + FILE_SEPARATOR +
-            "src" + FILE_SEPARATOR +
-            "main" + FILE_SEPARATOR +
-            "java" + FILE_SEPARATOR +
-            "data" + FILE_SEPARATOR +
-            "projects" + FILE_SEPARATOR; // TODO this is not java file, why put them into src/main/java ???
-
-    private static final String ES_MODULE_NAME = "evosuite-master";
-
-    public static final String EMPTY_ARRAY_AS_STRING = "[]";
-
-    public static final String BUG_EXPOSING_TEST_KEY = "BugExposingTest";
-
     public static final String EXTENSION_JAVA = ".java";
-
-    public static final String TEST_NAME = "_ESTest" + EXTENSION_JAVA;
 
     public static final Predicate<File> IS_JSON_FILE = file -> (file.getName().endsWith(EXTENSION_JSON));
 
@@ -66,16 +40,6 @@ public class Util {
     public static final Function<File, String> JSON_FILE_TO_STRING_WITHOUT_EXTENSION = file ->
             (file.getName().substring(0, file.getName().length() - EXTENSION_JSON.length()));
 
-    public static final Function<String, String[]> STRING_ARRAY_TO_INDEX = string ->
-            string.split("\\[")[1].split("]")[0].replaceAll(" ", "").split(",");
-
-    public static final Function<File[], String> GET_ESTEST = files ->
-            Arrays.stream(files)
-                    .filter(file -> file.getName().endsWith(TEST_NAME))
-                    .findFirst()
-                    .orElseThrow(() -> new RuntimeException("TestNotFound"))
-                    .getName();
-
     public static String extractDigitAtEndOfString(String string) {
         StringBuilder digits = new StringBuilder();
         int index = string.length() - 1;
@@ -85,78 +49,6 @@ public class Util {
             index--;
         }
         return digits.reverse().toString();
-    }
-
-    public static String getBaseClassPath(String project, String bugId) {
-        final String relativePathToClasses = getRelativePathToClasses(project, bugId);
-        return relativePathToClasses + PATH_SEPARATOR + getEvosuiteDependenciesPath();
-    }
-
-    public static int getComplianceLevel(String project, String bugId) {
-        try {
-            JSONParser parser = new JSONParser();
-            JSONObject jsonObject = (JSONObject) parser.parse(
-                    new FileReader(new File(PATH_TO_PROJECTS_JSON + project + EXTENSION_JSON))
-            );
-            final JSONObject complianceLevel = (JSONObject) jsonObject.get("complianceLevel");
-            return ((Long) ((JSONObject) complianceLevel.get(bugId)).get("target")).intValue();
-        } catch (Throwable e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    public static String getRelativePathToClasses(String project, String bugId) {
-        try {
-            JSONParser parser = new JSONParser();
-            JSONObject jsonObject = (JSONObject) parser.parse(
-                    new FileReader(new File(PATH_TO_PROJECTS_JSON + project + EXTENSION_JSON))
-            );
-            final JSONObject src = (JSONObject) jsonObject.get("src");
-            final JSONObject rightVersionSources = (JSONObject) src.get(
-                    src.keySet().size() == 1 ?
-                            src.keySet().stream().findAny().orElseThrow(() -> new RuntimeException(project + "#" + bugId)) :
-                            src.get(bugId) != null ? bugId :
-                                    (src.keySet()
-                                            .stream()
-                                            .sorted()
-                                            .filter(key -> Integer.parseInt(bugId) - Integer.parseInt((String) key) <= 0).
-                                                    reduce((k1, k2) -> k1)
-                                            .orElseThrow(() -> new RuntimeException(project + "#" + bugId))
-                                            .toString()
-                                    )
-            );
-            return PATH_TO_PROJECTS_REPOS + project + "_" + bugId +
-                    FILE_SEPARATOR + rightVersionSources.get(RELATIVE_PATH_SRC_BIN_KEY).toString()
-                    + PATH_SEPARATOR +
-                    PATH_TO_PROJECTS_REPOS + project + "_" + bugId +
-                    FILE_SEPARATOR + rightVersionSources.get(RELATIVE_PATH_TEST_BIN_KEY).toString();
-        } catch (Throwable e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private static String getEvosuiteDependenciesPath() {
-        if (!new File("target/.cp").exists()) {
-            String cmd = "mvn dependency:build-classpath -Dmdep.outputFile=target/.cp";
-            try {
-                Runtime.getRuntime().exec(cmd);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        try (BufferedReader reader = new BufferedReader(new FileReader(new File("target/.cp")))) {
-            return Arrays.stream(reader.lines()
-                    .findFirst()
-                    .orElseThrow(RuntimeException::new)
-                    .split(PATH_SEPARATOR))
-                    .filter(s -> s.contains(ES_MODULE_NAME))
-                    .findFirst()
-                    .orElseThrow(RuntimeException::new);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-
     }
 
 }


### PR DESCRIPTION
I moves specific code to test4-repair into a package and ignore it into the coverage because all the code is based on the test4-repair structure and files.

The core algorithm of AssertFixer remains untouched.